### PR TITLE
欠落しているモジュールの追加インポート

### DIFF
--- a/mastodon/internals.py
+++ b/mastodon/internals.py
@@ -9,6 +9,7 @@ import dateutil.parser
 import time
 import copy
 from curl_cffi import requests
+import requests.utils
 # import requests
 import re
 import collections


### PR DESCRIPTION
curl_cffi.requests.utilsが存在しないため,実行時に以下のエラーが発生する.  
```AttributeError: module 'curl_cffi.requests' has no attribute 'utils'```  
`import requests.utils` を追加することで解消する事が可能